### PR TITLE
Update base path of API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ bin/
 
 # IntelliJ Idea
 .idea
+/terraform/tfplan

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform('io.awspring.cloud:spring-cloud-aws-dependencies:3.0.0')
+    implementation platform('io.awspring.cloud:spring-cloud-aws-dependencies:3.0.2')
 
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.apache.commons:commons-compress:1.22'
@@ -29,14 +29,14 @@ dependencies {
     implementation 'org.tukaani:xz:1.9'
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-parameter-store'
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-sqs'
-    implementation 'org.postgresql:postgresql:42.5.0'
+    implementation 'org.postgresql:postgresql:42.5.4'
     implementation 'com.zaxxer:HikariCP:5.0.1'
-    implementation 'io.netty:netty-all:4.1.82.Final'
+    implementation 'io.netty:netty-all:4.1.90.Final'
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.graphql:spring-graphql-test'
-    testImplementation 'com.h2database:h2:2.1.214'
+    testImplementation 'com.h2database:h2:2.1.214' // Bumping to 2.2.220 causes tests to fail with "JdbcSQLSyntaxErrorException: Function alias "gen_random_uuid" already exists; SQL statement: CREATE ALIAS IF NOT EXISTS gen_random_uuid"
 }
 
 checkstyle {

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.64.0"
   constraints = ">= 4.64.0"
   hashes = [
+    "h1:4xXf+eZtKPiRyjle7HUPaVzF3h/6S8seNEIIbWlDbuk=",
     "h1:xstX5ub6MZ+PSrrZbB0ElhThX8N2ShQThR3m8nMZ928=",
     "zh:092614f767995140cf444cad1a97fb569885db16cb1c1dc9ee56e801232bac29",
     "zh:142e262fbb162c8a86493cfab4aadaf96a8572f1a3a6be444d465a4aee377dba",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   version     = "2.3.2"
   constraints = ">= 2.2.0"
   hashes = [
+    "h1:Vl0aixAYTV/bjathX7VArC5TVNkxBCsi3Vq7R4z1uvc=",
     "h1:ocyv0lvfyvzW4krenxV5CL4Jq5DiA3EUfoy8DR6zFMw=",
     "zh:2487e498736ed90f53de8f66fe2b8c05665b9f8ff1506f751c5ee227c7f457d1",
     "zh:3d8627d142942336cf65eea6eb6403692f47e9072ff3fa11c3f774a3b93130b3",
@@ -48,6 +50,7 @@ provider "registry.terraform.io/hashicorp/local" {
   version     = "2.4.0"
   constraints = ">= 2.2.3"
   hashes = [
+    "h1:R97FTYETo88sT2VHfMgkPU3lzCsZLunPftjSI5vfKe8=",
     "h1:ZUEYUmm2t4vxwzxy1BvN1wL6SDWrDxfH7pxtzX8c6d0=",
     "zh:53604cd29cb92538668fe09565c739358dc53ca56f9f11312b9d7de81e48fab9",
     "zh:66a46e9c508716a1c98efbf793092f03d50049fa4a83cd6b2251e9a06aca2acf",
@@ -69,6 +72,7 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = ">= 3.3.2"
   hashes = [
     "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
+    "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
     "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
     "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
     "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -94,6 +94,13 @@ resource "aws_cloudwatch_log_group" "app" {
 }
 
 /* -- App Config -- */
+resource "aws_ssm_parameter" "app_base_path" {
+  name = "${local.app_path}/spring.webflux.base-path"
+  type = "String"
+  value = var.app_base_path
+  overwrite = true
+}
+
 resource "aws_ssm_parameter" "app_db_url" {
   name = "${local.app_path}/spring.datasource.url"
   type = "String"

--- a/terraform/load_balancer.tf
+++ b/terraform/load_balancer.tf
@@ -28,7 +28,7 @@ resource "aws_lb_target_group" "app" {
   health_check {
     enabled = true
     matcher = "200,302"
-    path = "/"
+    path = var.app_base_path
   }
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,6 +3,11 @@ variable "app_name" {
     type = string
 }
 
+variable "app_base_path" {
+    default = "/api"
+    type = string
+}
+
 variable "db_name" {
     default = "swodlr"
     type = string


### PR DESCRIPTION
Closes https://github.com/podaac/swodlr/issues/72

Adds new tf var to control the base path where the app is being deployed which defaults to `/api`. Add SSM config parameter to store value.

Tested in SIT by manually terraform apply-ing and verified `https://d2vi6m9o1fqqk5.cloudfront.net/api/config` returns 
```
{
    "authenticationUri": "/oauth2/authorization/edl"
}
```