### PR TITLE
Terraform Hotfixes

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -122,14 +122,20 @@ resource "aws_ssm_parameter" "app_db_password" {
   value = aws_ssm_parameter.db_app_password.value
 }
 
+resource "aws_ssm_parameter" "app_edl_base_path" {
+  name = "${local.app_path}/swodlr.security.edl-base-url"
+  type = "String"
+  value = var.edl_base_url
+}
+
 resource "aws_ssm_parameter" "app_edl_client_id" {
-  name = "${local.app_path}/spring.security.oauth2.client.registration.edl.client-id"
+  name = "${local.app_path}/swodlr.security.edl-client-id"
   type = "String"
   value = var.edl_client_id
 }
 
 resource "aws_ssm_parameter" "app_edl_client_secret" {
-  name = "${local.app_path}/spring.security.oauth2.client.registration.edl.client-secret"
+  name = "${local.app_path}/swodlr.security.edl-client-secret"
   type = "String"
   value = var.edl_client_secret
 }

--- a/terraform/environments/uat.env
+++ b/terraform/environments/uat.env
@@ -2,5 +2,5 @@ export REGION=us-west-2
 export BUCKET=podaac-services-uat-terraform
 
 export TF_VAR_container_image_tag=develop
-export TF_VAR_active_profiles="[\"dev\"]"
+export TF_VAR_active_profiles="[\"\"]"
 export TF_VAR_tea_mapping="{\"podaac-swot-sit-swodlr-protected\"=\"archive.swot.podaac.sit.earthdata.nasa.gov\"}"

--- a/terraform/load_balancer.tf
+++ b/terraform/load_balancer.tf
@@ -27,8 +27,8 @@ resource "aws_lb_target_group" "app" {
 
   health_check {
     enabled = true
-    matcher = "200,302"
-    path = var.app_base_path
+    matcher = "200,404"  # Replace this later
+    path = "/"
   }
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -40,6 +40,10 @@ variable "container_image_tag" {
     type = string
 }
 
+variable "edl_base_url" {
+    type = string
+}
+
 variable "edl_client_id" {
     type = string
 }


### PR DESCRIPTION
- Update terraform to set `swodlr.security` SSM parameters
- Remove legacy OAuth2 client parameters
- Add variable for EDL base path
- Disable `dev` in UAT solving CORS issue