### PR TITLE
GraphQL Request Logging

### DIFF
--- a/src/main/java/gov/nasa/podaac/swodlr/metrics/GraphQlRequest.java
+++ b/src/main/java/gov/nasa/podaac/swodlr/metrics/GraphQlRequest.java
@@ -1,0 +1,57 @@
+package gov.nasa.podaac.swodlr.metrics;
+
+import gov.nasa.podaac.swodlr.security.GraphQlUserInjector;
+import gov.nasa.podaac.swodlr.user.UserReference;
+import graphql.GraphQLContext;
+import graphql.execution.ExecutionStepInfo;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
+import graphql.language.OperationDefinition;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.Map;
+
+public class GraphQlRequest {
+  private final String username;
+  private final String operation;
+  private final String path;
+  private final String executionId;
+  private final Map<String, Object> arguments;
+
+  public GraphQlRequest(InstrumentationFieldFetchParameters parameters) {
+    ExecutionStepInfo execStepInfo = parameters.getExecutionStepInfo();
+    DataFetchingEnvironment environment = parameters.getEnvironment();
+    OperationDefinition opDef = environment.getOperationDefinition();
+    GraphQLContext graphQlContext = environment.getGraphQlContext();
+
+    UserReference userReference = graphQlContext.get(GraphQlUserInjector.USER_REFERENCE_KEY);
+    if (userReference == null) {
+      this.username = null;
+    } else {
+      this.username = userReference.fetch().getUsername();
+    }
+
+    this.operation = opDef.getOperation().name();
+    this.path = execStepInfo.getPath().toString();
+    this.executionId = environment.getExecutionId().toString();
+    this.arguments = Map.copyOf(environment.getArguments());
+  }
+
+  public Map<String, Object> getArguments() {
+    return this.arguments;
+  }
+
+  public String getPath() {
+    return this.path;
+  }
+
+  public String getUser() {
+    return this.username;
+  }
+
+  public String getOperation() {
+    return this.operation;
+  }
+
+  public String getExecutionId() {
+    return this.executionId;
+  }
+}

--- a/src/main/java/gov/nasa/podaac/swodlr/metrics/GraphQlRequest.java
+++ b/src/main/java/gov/nasa/podaac/swodlr/metrics/GraphQlRequest.java
@@ -32,7 +32,8 @@ public class GraphQlRequest {
     this.operation = opDef.getOperation().name();
     this.path = execStepInfo.getPath().toString();
     this.executionId = environment.getExecutionId().toString();
-    this.arguments = Map.copyOf(environment.getArguments());
+    this.arguments = (environment.getArguments() == null)
+      ? Map.copyOf(environment.getArguments()) : Map.of();
   }
 
   public Map<String, Object> getArguments() {

--- a/src/main/java/gov/nasa/podaac/swodlr/metrics/GraphQlRequestLogger.java
+++ b/src/main/java/gov/nasa/podaac/swodlr/metrics/GraphQlRequestLogger.java
@@ -17,7 +17,9 @@ public class GraphQlRequestLogger extends SimpleInstrumentation {
   private final ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json().build();
   
   @Override
-  public InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters) {
+  public InstrumentationContext<Object> beginFieldFetch(
+      InstrumentationFieldFetchParameters parameters
+  ) {
     return SimpleInstrumentationContext.whenDispatched((future) -> {
       try {
         logger.info(objectMapper.writeValueAsString(new GraphQlRequest(parameters)));

--- a/src/main/java/gov/nasa/podaac/swodlr/metrics/GraphQlRequestLogger.java
+++ b/src/main/java/gov/nasa/podaac/swodlr/metrics/GraphQlRequestLogger.java
@@ -1,0 +1,29 @@
+package gov.nasa.podaac.swodlr.metrics;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.SimpleInstrumentation;
+import graphql.execution.instrumentation.SimpleInstrumentationContext;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GraphQlRequestLogger extends SimpleInstrumentation {
+  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private final ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json().build();
+  
+  @Override
+  public InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters) {
+    return SimpleInstrumentationContext.whenDispatched((future) -> {
+      try {
+        logger.info(objectMapper.writeValueAsString(new GraphQlRequest(parameters)));
+      } catch (JsonProcessingException jsonEx) {
+        logger.error("Exception thrown while serializing GraphQL request", jsonEx);
+      }
+    });
+  }
+}

--- a/src/main/java/gov/nasa/podaac/swodlr/metrics/MetricsConfiguration.java
+++ b/src/main/java/gov/nasa/podaac/swodlr/metrics/MetricsConfiguration.java
@@ -8,13 +8,13 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class MetricsConfiguration {
-    @Autowired
-    private GraphQlRequestLogger graphQlRequestLogger;
+  @Autowired
+  private GraphQlRequestLogger graphQlRequestLogger;
 
-    @Bean
-    public GraphQlSourceBuilderCustomizer graphQlSourceBuilderCustomizer() {
-        return customizer -> {
-            customizer.instrumentation(List.of(graphQlRequestLogger));
-        };
-    }
+  @Bean
+  public GraphQlSourceBuilderCustomizer graphQlSourceBuilderCustomizer() {
+    return customizer -> {
+      customizer.instrumentation(List.of(graphQlRequestLogger));
+    };
+  }
 }

--- a/src/main/java/gov/nasa/podaac/swodlr/metrics/MetricsConfiguration.java
+++ b/src/main/java/gov/nasa/podaac/swodlr/metrics/MetricsConfiguration.java
@@ -1,0 +1,20 @@
+package gov.nasa.podaac.swodlr.metrics;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.graphql.GraphQlSourceBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MetricsConfiguration {
+    @Autowired
+    private GraphQlRequestLogger graphQlRequestLogger;
+
+    @Bean
+    public GraphQlSourceBuilderCustomizer graphQlSourceBuilderCustomizer() {
+        return customizer -> {
+            customizer.instrumentation(List.of(graphQlRequestLogger));
+        };
+    }
+}

--- a/src/main/java/gov/nasa/podaac/swodlr/security/GraphQlUserInjector.java
+++ b/src/main/java/gov/nasa/podaac/swodlr/security/GraphQlUserInjector.java
@@ -13,6 +13,8 @@ import reactor.core.publisher.Mono;
 @Component
 @Profile("!test")
 public class GraphQlUserInjector implements WebGraphQlInterceptor {
+  public static final String USER_REFERENCE_KEY = "userRef";
+
   @Override
   public Mono<WebGraphQlResponse> intercept(WebGraphQlRequest request, Chain chain) {
     return Mono.deferContextual((context) -> {
@@ -21,7 +23,7 @@ public class GraphQlUserInjector implements WebGraphQlInterceptor {
           UserReference userReference = session.getAttribute("user");
           if (userReference != null) {
             request.configureExecutionInput((executionInput, builder) -> {
-              builder.graphQLContext(Collections.singletonMap("userRef", userReference));
+              builder.graphQLContext(Collections.singletonMap(USER_REFERENCE_KEY, userReference));
               return builder.build();
             });
           }


### PR DESCRIPTION
GraphQL logging for SWODLR APIs based on the java-graphql instrumentation APIs

https://www.graphql-java.com/documentation/instrumentation/

Example logs:

```
2024-05-30 00:15:56.783  INFO 16430 --- [r-http-kqueue-2] g.n.p.s.metrics.GraphQlRequestLogger     : {"operation":"QUERY","path":"/currentUser","executionId":"ca95ea89-1","arguments":{},"user":"joshgarde"}
2024-05-30 00:15:56.796  INFO 16430 --- [r-http-kqueue-2] g.n.p.s.metrics.GraphQlRequestLogger     : {"operation":"QUERY","path":"/currentUser/id","executionId":"ca95ea89-1","arguments":{},"user":"joshgarde"}
2024-05-30 00:15:56.800  INFO 16430 --- [r-http-kqueue-2] g.n.p.s.metrics.GraphQlRequestLogger     : {"operation":"QUERY","path":"/currentUser/firstName","executionId":"ca95ea89-1","arguments":{},"user":"joshgarde"}
2024-05-30 00:15:56.802  INFO 16430 --- [r-http-kqueue-2] g.n.p.s.metrics.GraphQlRequestLogger     : {"operation":"QUERY","path":"/currentUser/lastName","executionId":"ca95ea89-1","arguments":{},"user":"joshgarde"}
2024-05-30 00:15:56.804  INFO 16430 --- [r-http-kqueue-2] g.n.p.s.metrics.GraphQlRequestLogger     : {"operation":"QUERY","path":"/currentUser/email","executionId":"ca95ea89-1","arguments":{},"user":"joshgarde"}
```

Closes https://github.com/podaac/swodlr/issues/134